### PR TITLE
fix typo

### DIFF
--- a/ckanext/panama/templates/header.html
+++ b/ckanext/panama/templates/header.html
@@ -113,7 +113,7 @@
                                             ('home', _('Home').upper()),
                                             ('search', _('Datasets').upper()),
                                             ('group_index', _('Groups').upper()),
-                                            ('organization_index', _('Organizations').upper()),
+                                            ('organizations_index', _('Organizations').upper()),
                                             ('ckanext_showcase_index', _('APPS').upper()),
                                             ('contact_form', _('Contact').upper()),
                                             ('about', _('About').upper())


### PR DESCRIPTION
There is typo for `organizations_index` route when creating the navigation menu